### PR TITLE
Makes default values directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,6 @@
 exports.forDry;
 
-Array.prototype.forDry = function(cb, start=null, operator=null, length=null, iterator=null) {
-    
-    if(start === null) {
-        start = 0;
-    }
-    
+Array.prototype.forDry = function(cb, start=0, operator='<=', length='length - 1', iterator='++') {
     let solution,
         index = start,
         operators = {
@@ -47,20 +42,7 @@ Array.prototype.forDry = function(cb, start=null, operator=null, length=null, it
             'length': () => {
                     return this.length; 
                 },  
-        }; 
-
-
-    if(operator === null) {
-        operator = '<=';
-    }
-    
-    if(length === null) {
-        length = 'length - 1';
-    }
-
-    if(iterator === null) {
-        iterator = '++'; 
-    }
+        };
     
     for(index = start; operators[operator](); iterators[iterator]()) {
         solution = cb(index, this[index]);


### PR DESCRIPTION
Skips the additional step of checking if something's null.

Why take the additional step with the `if` statements to check if these parameters are null? It seems more straightforward to go ahead and give them their respective defaults in the parameter list.